### PR TITLE
track specific vehicles to improve threshold reminders

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "axios": "^1.7.2",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "fast-json-stable-stringify": "^2.1.0",
         "fast-xml-parser": "^5.3.2",
         "firebase-admin": "^13.6.0",
         "lru-cache": "^11.2.5",

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -1,5 +1,5 @@
 import { updateBusPositions, initializeRoutes, rebuildGraph } from './services/graphBuilder';
-import { processReminders } from './services/reminder';
+import { processUniversityReminders } from './services/reminder';
 
 /**
  * Starts background jobs for updating bus positions, initializing routes, and rebuilding the graph.
@@ -13,7 +13,7 @@ export function startBackgroundJobs() {
     setInterval(updateBusPositions, 7500);
     setInterval(initializeRoutes, 60000);
     setInterval(rebuildGraph, 60 * 1000);
-    setInterval(processReminders, 7500);
+    setInterval(processUniversityReminders, 7500);
 
     console.log("Background jobs started.");
 }

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -1,5 +1,5 @@
 import { updateBusPositions, initializeRoutes, rebuildGraph } from './services/graphBuilder';
-import { processUniversityReminders } from './services/reminder';
+import { processRideReminders, processUniversityReminders } from './services/reminder';
 
 /**
  * Starts background jobs for updating bus positions, initializing routes, and rebuilding the graph.
@@ -14,6 +14,7 @@ export function startBackgroundJobs() {
     setInterval(initializeRoutes, 60000);
     setInterval(rebuildGraph, 60 * 1000);
     setInterval(processUniversityReminders, 7500);
+    setInterval(processRideReminders, 7500);
 
     console.log("Background jobs started.");
 }

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -499,10 +499,12 @@ export function setReminder(req: express.Request, res: express.Response) {
         res.send(result.error.message);
     } else {
         const { token, stpid, rtid, thresh } = result.data;
-        reminderService.reminderSubscriptions.add(
+        // TODO: support the ride
+        reminderService.universityReminderSubscriptions.add(
             reminderService.Event({ stpid, rtid }),
             thresh,
-            reminderService.RegistrationToken(token)
+            reminderService.RegistrationToken(token),
+            state.cachedPredsByStopId
         );
         res.sendStatus(200);
     }
@@ -522,7 +524,8 @@ export function unsetReminder(req: express.Request, res: express.Response) {
         res.send(result.error.message);
     } else {
         const { token ,stpid, rtid } = result.data;
-        reminderService.reminderSubscriptions.remove(
+        // TODO: support the ride
+        reminderService.universityReminderSubscriptions.remove(
             { stpid, rtid } as reminderService.Event, reminderService.RegistrationToken(token)
         );
         res.sendStatus(200);
@@ -545,7 +548,8 @@ export function swapToken(req: express.Request, res: express.Response) {
         res.send(result.error.message);
     } else {
         const { oldTok, newTok } = req.body;
-        reminderService.reminderSubscriptions.swapToken(oldTok, newTok);
+        // TODO: support the ride
+        reminderService.universityReminderSubscriptions.swapToken(oldTok, newTok);
         res.sendStatus(200);
     }
 }
@@ -564,8 +568,14 @@ export function activeRemindersForToken(
     const token = reminderService.RegistrationToken(req.params.registrationToken);
     console.log(`Got request for active reminders of ${token}`);
     res.status(200);
+    // TODO: support the ride
     res.send({
-        reminders: reminderService.reminderSubscriptions.activeRemindersFor(token)
+        reminders: reminderService
+            .universityReminderSubscriptions
+            .activeRemindersFor(token)
+            .map((r) => {
+                return { stpid: r.event.stpid, rtid: r.event.rtid, thresh: null, eta: null };
+            })
     });
 }
 router.get('/activeReminders/:registrationToken', activeRemindersForToken);
@@ -593,11 +603,14 @@ export function modifyReminders(req: express.Request, res: express.Response) {
         for (const modification of modifications) {
             const event = { stpid: modification.stpid, rtid: modification.rtid } as reminderService.Event;
             if (modification.action == "set") {
-                reminderService.reminderSubscriptions.add(
-                    event, modification.thresh, reminderService.RegistrationToken(token)
+                // TODO: support the ride
+                reminderService.universityReminderSubscriptions.add(
+                    event, modification.thresh, reminderService.RegistrationToken(token), state.cachedPredsByStopId
                 );            
             } else {
-                reminderService.reminderSubscriptions.remove(event, reminderService.RegistrationToken(token));
+                reminderService.universityReminderSubscriptions.remove(
+                    event, reminderService.RegistrationToken(token)
+                );
             }
         }
         res.sendStatus(200);

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -2,7 +2,6 @@ import express from "express";
 import * as path from "path";
 import * as process from "node:process";
 import axios from "axios";
-import { getMessaging } from "firebase-admin/messaging";
 import * as z from "zod";
 import * as state from '../state/transitState';
 import * as meta from '../services/metadata';
@@ -507,9 +506,9 @@ export function setReminder(req: express.Request, res: express.Response) {
         }
         const { reminderSubscriptions, predsByStopId } = info;
         reminderSubscriptions.add(
-            reminderService.Event({ stpid, rtid }),
+            reminderService.baseEvent({ stpid, rtid }),
             thresh,
-            reminderService.RegistrationToken(token),
+            reminderService.registrationToken(token),
             predsByStopId,
             Date.now(),
         );
@@ -539,7 +538,7 @@ export function unsetReminder(req: express.Request, res: express.Response) {
         }
         const { reminderSubscriptions } = info;
         reminderSubscriptions.remove(
-            reminderService.Event({ stpid, rtid }), reminderService.RegistrationToken(token)
+            reminderService.baseEvent({ stpid, rtid }), reminderService.registrationToken(token)
         );
         res.sendStatus(200);
     }
@@ -568,31 +567,37 @@ export function swapToken(req: express.Request, res: express.Response) {
 }
 router.post('/swapToken', swapToken);
 
+type ActiveReminderInfo = { stpid: string, rtid: string, thresh: number | null, eta: number | null };
+
 /**
  * @param req - Express request, token is path encoded
  * @param res - Express response 
  */
 export function activeRemindersForToken(
     req: express.Request,
-    res: express.Response<{
-        reminders: Array<{ stpid: string, rtid: string, thresh: number | null, eta: number | null }>
-    }>
+    res: express.Response<{ reminders: Array<ActiveReminderInfo> }>
 ) {
-    const token = reminderService.RegistrationToken(req.params.registrationToken);
+    const subscriptionInfo = (r: reminderService.PreThreshold | reminderService.PostThreshold):
+        ActiveReminderInfo =>
+    {
+        return {
+            stpid: r.event.stpid,
+            rtid: r.event.rtid,
+            thresh: r.stage === 0 ? r.thresh : null,
+            eta: r.stage === 0 ? r.candidateVidPredPrev : r.vidPredPrev
+        };
+    };
+    const token = reminderService.registrationToken(req.params.registrationToken);
     console.log(`Got request for active reminders of ${token}`);
     res.status(200);
     const universityReminders = reminderService
         .universityReminderSubscriptions
         .activeRemindersFor(token)
-        .map((r) => {
-            return { stpid: r.event.stpid, rtid: r.event.rtid, thresh: null, eta: null };
-        });
+        .map(subscriptionInfo);
     const rideReminders = reminderService
         .rideReminderSubscriptions
         .activeRemindersFor(token)
-        .map((r) => {
-            return { stpid: r.event.stpid, rtid: r.event.rtid, thresh: null, eta: null };
-        });
+        .map(subscriptionInfo);
     res.send({
         reminders: universityReminders.concat(rideReminders)
     });
@@ -620,7 +625,7 @@ export function modifyReminders(req: express.Request, res: express.Response) {
     } else {
         const { token, modifications } = result.data;
         for (const modification of modifications) {
-            const event = reminderService.Event({ stpid: modification.stpid, rtid: modification.rtid });
+            const event = reminderService.baseEvent({ stpid: modification.stpid, rtid: modification.rtid });
             const info = reminderService.infoToUseForRoute(modification.rtid);
             if (info === null) {
                 res.status(400);
@@ -632,13 +637,13 @@ export function modifyReminders(req: express.Request, res: express.Response) {
                 reminderSubscriptions.add(
                     event,
                     modification.thresh,
-                    reminderService.RegistrationToken(token),
+                    reminderService.registrationToken(token),
                     predsByStopId,
                     Date.now()
                 );            
             } else {
                 reminderSubscriptions.remove(
-                    event, reminderService.RegistrationToken(token)
+                    event, reminderService.registrationToken(token)
                 );
             }
         }

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -499,12 +499,19 @@ export function setReminder(req: express.Request, res: express.Response) {
         res.send(result.error.message);
     } else {
         const { token, stpid, rtid, thresh } = result.data;
-        // TODO: support the ride
-        reminderService.universityReminderSubscriptions.add(
+        const info = reminderService.infoToUseForRoute(rtid);
+        if (info === null) {
+            res.status(400);
+            res.send(`Invalid route ${rtid}`);
+            return;
+        }
+        const { reminderSubscriptions, predsByStopId } = info;
+        reminderSubscriptions.add(
             reminderService.Event({ stpid, rtid }),
             thresh,
             reminderService.RegistrationToken(token),
-            state.cachedPredsByStopId
+            predsByStopId,
+            Date.now(),
         );
         res.sendStatus(200);
     }
@@ -524,9 +531,15 @@ export function unsetReminder(req: express.Request, res: express.Response) {
         res.send(result.error.message);
     } else {
         const { token ,stpid, rtid } = result.data;
-        // TODO: support the ride
-        reminderService.universityReminderSubscriptions.remove(
-            { stpid, rtid } as reminderService.Event, reminderService.RegistrationToken(token)
+        const info = reminderService.infoToUseForRoute(rtid);
+        if (info === null) {
+            res.status(400);
+            res.send(`Invalid route ${rtid}`);
+            return;
+        }
+        const { reminderSubscriptions } = info;
+        reminderSubscriptions.remove(
+            reminderService.Event({ stpid, rtid }), reminderService.RegistrationToken(token)
         );
         res.sendStatus(200);
     }
@@ -548,8 +561,8 @@ export function swapToken(req: express.Request, res: express.Response) {
         res.send(result.error.message);
     } else {
         const { oldTok, newTok } = req.body;
-        // TODO: support the ride
         reminderService.universityReminderSubscriptions.swapToken(oldTok, newTok);
+        reminderService.rideReminderSubscriptions.swapToken(oldTok, newTok);
         res.sendStatus(200);
     }
 }
@@ -568,14 +581,20 @@ export function activeRemindersForToken(
     const token = reminderService.RegistrationToken(req.params.registrationToken);
     console.log(`Got request for active reminders of ${token}`);
     res.status(200);
-    // TODO: support the ride
+    const universityReminders = reminderService
+        .universityReminderSubscriptions
+        .activeRemindersFor(token)
+        .map((r) => {
+            return { stpid: r.event.stpid, rtid: r.event.rtid, thresh: null, eta: null };
+        });
+    const rideReminders = reminderService
+        .rideReminderSubscriptions
+        .activeRemindersFor(token)
+        .map((r) => {
+            return { stpid: r.event.stpid, rtid: r.event.rtid, thresh: null, eta: null };
+        });
     res.send({
-        reminders: reminderService
-            .universityReminderSubscriptions
-            .activeRemindersFor(token)
-            .map((r) => {
-                return { stpid: r.event.stpid, rtid: r.event.rtid, thresh: null, eta: null };
-            })
+        reminders: universityReminders.concat(rideReminders)
     });
 }
 router.get('/activeReminders/:registrationToken', activeRemindersForToken);
@@ -601,14 +620,24 @@ export function modifyReminders(req: express.Request, res: express.Response) {
     } else {
         const { token, modifications } = result.data;
         for (const modification of modifications) {
-            const event = { stpid: modification.stpid, rtid: modification.rtid } as reminderService.Event;
+            const event = reminderService.Event({ stpid: modification.stpid, rtid: modification.rtid });
+            const info = reminderService.infoToUseForRoute(modification.rtid);
+            if (info === null) {
+                res.status(400);
+                res.send(`Invalid route ${modification.rtid}`);
+                return;
+            }
+            const { reminderSubscriptions, predsByStopId } = info;
             if (modification.action == "set") {
-                // TODO: support the ride
-                reminderService.universityReminderSubscriptions.add(
-                    event, modification.thresh, reminderService.RegistrationToken(token), state.cachedPredsByStopId
+                reminderSubscriptions.add(
+                    event,
+                    modification.thresh,
+                    reminderService.RegistrationToken(token),
+                    predsByStopId,
+                    Date.now()
                 );            
             } else {
-                reminderService.universityReminderSubscriptions.remove(
+                reminderSubscriptions.remove(
                     event, reminderService.RegistrationToken(token)
                 );
             }

--- a/src/services/graphBuilder.ts
+++ b/src/services/graphBuilder.ts
@@ -81,6 +81,7 @@ export async function rebuildGraph() {
         });
         const rawRidePreds = await rideBus.fetchPredictions(Array.from(rideStopIds), DEFAULT_RIDE_ROUTES);
         const formattedRidePreds = processRidePredictions(rawRidePreds);
+        populateRideLookupMaps(formattedRidePreds);
         updateRideLookups(formattedRidePreds);
         
         state.setCachedGraph({
@@ -96,7 +97,7 @@ export async function rebuildGraph() {
 
 /**
  * Populates lookup maps for stop names and trip-to-route mappings.
- * @paramw preds List of processed predictions
+ * @param preds List of processed predictions
  */
 function populateLookupMaps(preds: any[]) {
     Object.values(state.cachedRoutes).forEach((patterns: any) => {
@@ -121,6 +122,27 @@ function populateLookupMaps(preds: any[]) {
                 state.tatripidToRt[trip.tatripid] = firstStopWithRt.rt;
             }
         }
+    });
+}
+
+/**
+ * Populates the lookup map for ride stop names
+ * @param preds List of processed predictions from the ride
+ */
+function populateRideLookupMaps(preds: any[]) {
+    Object.values(state.cachedRideRoutes).forEach((patterns: any) => {
+        patterns?.forEach((p: any) => p.pt?.forEach((pt: any) => {
+            if (pt.stpid && pt.stpnm) {
+                state.rideStopIdToName[pt.stpid] = pt.stpnm;
+            }
+        }));
+    });
+    preds.forEach((trip: any) => {
+        trip.stops.forEach((stop: any) => {
+            if (stop.stpid && stop.stpnm) {
+                state.rideStopIdToName[stop.stpid] = stop.stpnm;
+            }
+        });
     });
 }
 
@@ -356,6 +378,11 @@ function processRidePredictions(rawChunks: any[]) {
                 stop.rtdir = prd.rtdir;
                 stop.rt = prd.rt;
                 stop.prdctdn = prd.prdctdn === "DUE" ? "1" : prd.prdctdn;
+                // console.log(prd.prdtm);
+                // prdtm is in format YYYYMMDD HH:MM:SS
+                // stop.prdtm = parseInt(prd.prdtm);
+                // TODO: use actual timestamp
+                stop.prdtm = Date.now() + (parseInt(stop.prdctdn) + 0.5) * 60 * 1000;
             });
         }
         return acc;

--- a/src/services/graphBuilder.ts
+++ b/src/services/graphBuilder.ts
@@ -212,6 +212,7 @@ function processPredictions(rawChunks: any[]) {
                 stop.rtdir = prd.rtdir;
                 stop.rt = prd.rt;
                 stop.prdctdn = prd.prdctdn === "DUE" ? "1" : prd.prdctdn;
+                stop.prdtm = parseInt(prd.prdtm);
             });
         }
         return acc;

--- a/src/services/graphBuilder.ts
+++ b/src/services/graphBuilder.ts
@@ -421,7 +421,7 @@ function updateRideLookups(preds: any[]) {
 }
 
 /** Sorts every prediction list contained in `x` by arrival timestamp */
-function sortPreds(x: Record<string, state.Prediction[]>) {
+export function sortPreds(x: Record<string, state.Prediction[]>) {
     for (const k in x) {
         x[k].sort((lhs, rhs) => lhs.prdtm - rhs.prdtm);
     }

--- a/src/services/graphBuilder.ts
+++ b/src/services/graphBuilder.ts
@@ -387,6 +387,9 @@ function updatePredictionLookups(preds: any[]) {
             }
         });
     });
+    // sort
+    sortPreds(state.cachedPredsByStopId);
+    sortPreds(state.cachedPredsByVid);
 }
 
 
@@ -412,6 +415,16 @@ function updateRideLookups(preds: any[]) {
             }
         });
     });
+    // sort
+    sortPreds(state.cachedRidePredsByStopId);
+    sortPreds(state.cachedRidePredsByVid);
+}
+
+/** Sorts every prediction list contained in `x` by arrival timestamp */
+function sortPreds(x: Record<string, state.Prediction[]>) {
+    for (const k in x) {
+        x[k].sort((lhs, rhs) => lhs.prdtm - rhs.prdtm);
+    }
 }
 
 /**

--- a/src/services/mbus.ts
+++ b/src/services/mbus.ts
@@ -67,7 +67,8 @@ export async function fetchPredictions(stopIds: string[], routes: string[]) {
                     requestType: 'getpredictions',
                     stpid: chunk.join(','),
                     rt: routes.join(','),
-                    tmres: 's'
+                    tmres: 's',
+                    unixTime: true,
                 }
             });
             return res.data;

--- a/src/services/reminder.test.ts
+++ b/src/services/reminder.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect } from 'vitest';
 
 import * as r from "./reminder";
 import { testing as t } from "./reminder";
@@ -89,34 +89,106 @@ describe('Reminders', () => {
     });
 
     it('should send at the stop notifications', () => {
-        // TODO
-        expect(false).toBe(true);
-        // const subs = new t.ReminderSubscriptions
+        const subs = new t.ReminderSubscriptions();
+        const { byStop, byVid } = createCaches([
+            { rt: testEvent.rtid, vid: "vid1", stpid: testEvent.stpid, prdtm: Date.now() + 4 * 60 * 1000, prdctdn: "2" }
+        ]);
+        subs.add(testEvent, 3, testToken, byStop, Date.now());
+        subs.process(byStop, byVid, Date.now());
+        byStop["stop1"][0].prdctdn = "DUE"
+        expect(byStop["stop1"][0].prdctdn).toEqual(byVid["vid1"][0].prdctdn);
+        const reminders = subs.process(byStop, byVid, Date.now());
+        expect(reminders.atTheStop.size).toBe(1);
     });
 
     it('should send delayed notifications', () => {
-        // TODO 
-        expect(false).toBe(true);
+        const subs = new t.ReminderSubscriptions();
+        const { byStop, byVid } = createCaches([
+            { rt: testEvent.rtid, vid: "vid1", stpid: testEvent.stpid, prdtm: Date.now() + 4 * 60 * 1000, prdctdn: "4" } 
+        ]);
+        subs.add(testEvent, 3, testToken, byStop, Date.now());
+        subs.process(byStop, byVid, Date.now());
+        byVid["vid1"][0].prdctdn = "5";
+        let reminders = subs.process(byStop, byVid, Date.now());
+        expect(reminders.delayed.size).toBe(1);
+
+        // now test behavior in stage 1
+        byVid["vid1"][0].prdctdn = "3";
+        const remindersToStage1 = subs.process(byStop, byVid, Date.now() + 2 * 60 * 1000);
+        expect(remindersToStage1.reminder.size).toBe(1);
+        expect(subs.subscriptions[0].subscription.stage).toBe(1);
+        byVid["vid1"][0].prdctdn = "4";
+        reminders = subs.process(byStop, byVid, Date.now() + 2 * 60 * 1000);
+        expect(reminders.delayed.size).toBe(1);
     });
 
-    it('should send disappeared notifications', () => {
-        // TODO
-        expect(false).toBe(true);
+    it('should send disappeared notifications (stage 0)', () => {
+        const subs = new t.ReminderSubscriptions();
+        const { byStop, byVid: _ } = createCaches([
+            { rt: testEvent.rtid, vid: "vid1", stpid: testEvent.stpid, prdtm: Date.now() + 4 * 60 * 1000, prdctdn: "4" }
+        ]);
+        subs.add(testEvent, 3, testToken, byStop, Date.now());
+        const reminders = subs.process({}, {}, Date.now());
+        expect(reminders.disappeared.size).toBe(1);
+    });
+
+    it('should send disappeared notifications (stage 1)', () => {
+        const subs = new t.ReminderSubscriptions();
+        const { byStop, byVid } = createCaches([
+            { rt: testEvent.rtid, vid: "vid1", stpid: testEvent.stpid, prdtm: Date.now() + 5 * 60 * 1000, prdctdn: "5" } 
+        ]);
+        subs.add(testEvent, 4, testToken, byStop, Date.now());
+        subs.process(byStop, byVid, Date.now());
+
+        // to stage 1
+        byVid["vid1"][0].prdctdn = "4";
+        const remindersToStage1 = subs.process(byStop, byVid, Date.now() + 2 * 60 * 1000);
+        expect(remindersToStage1.reminder.size).toBe(1);
+        expect(subs.subscriptions[0].subscription.stage).toBe(1);
+
+        const reminders = subs.process({}, {}, Date.now());
+        expect(reminders.disappeared.size).toBe(1);
     });
 
     it('should override some delayed notifications', () => {
-        // TODO
-        expect(false).toBe(true);
+        const subs = new t.ReminderSubscriptions();
+        const { byStop, byVid } = createCaches([
+            { rt: testEvent.rtid, vid: "vid1", stpid: testEvent.stpid, prdtm: Date.now() + 4 * 60 * 1000, prdctdn: "4" } 
+        ]);
+        subs.add(testEvent, 3, testToken, byStop, Date.now());
+        subs.process(byStop, byVid, Date.now());
+        byVid["vid1"][0].prdctdn = "5";
+        let reminders = subs.process(byStop, byVid, Date.now());
+        expect(reminders.delayed.size).toBe(1);
+
+        // now test behavior in stage 1
+        byVid["vid1"][0].prdctdn = "3";
+        const remindersToStage1 = subs.process(byStop, byVid, Date.now() + 2 * 60 * 1000);
+        expect(remindersToStage1.reminder.size).toBe(1);
+        expect(subs.subscriptions[0].subscription.stage).toBe(1);
+        byVid["vid1"][0].prdctdn = "20";
+        reminders = subs.process(byStop, byVid, Date.now() + 2 * 60 * 1000);
+        expect(reminders.delayed.size).toBe(0);
+        expect(reminders.atTheStop.size).toBe(1);
     });
 
     it('should override some disappeared notifications', () => {
-        // TODO
-        expect(false).toBe(true);
-    });
+        const subs = new t.ReminderSubscriptions();
+        const { byStop, byVid } = createCaches([
+            { rt: testEvent.rtid, vid: "vid1", stpid: testEvent.stpid, prdtm: Date.now() + 5 * 60 * 1000, prdctdn: "5" } 
+        ]);
+        subs.add(testEvent, 4, testToken, byStop, Date.now());
+        subs.process(byStop, byVid, Date.now());
 
-    it('should have reasonable performance', () => {
-        // TODO
-        expect(false).toBe(true);
+        // to stage 1
+        byVid["vid1"][0].prdctdn = "3";
+        const remindersToStage1 = subs.process(byStop, byVid, Date.now() + 2 * 60 * 1000);
+        expect(remindersToStage1.reminder.size).toBe(1);
+        expect(subs.subscriptions[0].subscription.stage).toBe(1);
+
+        const reminders = subs.process({}, {}, Date.now());
+        expect(reminders.disappeared.size).toBe(0);
+        expect(reminders.atTheStop.size).toBe(1);
     });
 });
 

--- a/src/services/reminder.test.ts
+++ b/src/services/reminder.test.ts
@@ -7,6 +7,7 @@ import { sortPreds } from './graphBuilder';
 
 const testToken = r.RegistrationToken("token1");
 const testEvent = r.Event({ stpid: "stop1", rtid: "route1" });
+const testEventDiffRt = r.Event({ stpid: "stop1", rtid: "route2" });
 
 function createCaches(preds: Prediction[]): { byStop: Record<string, Prediction[]>, byVid: Record<string, Prediction[]> } {
     const byStop: Record<string, Prediction[]> = {};
@@ -67,28 +68,55 @@ describe('Reminders', () => {
         expect(reminders.disappeared.size).toBe(0);
     });
 
+    it('should not trigger for busses of other routes', () => {
+        const subs = new t.ReminderSubscriptions();
+        const { byStop, byVid } = createCaches([
+            { rt: testEventDiffRt.rtid, vid: "vid1", stpid: testEvent.stpid, prdtm: Date.now() + 4 * 60 * 1000, prdctdn: "2" }
+        ]);
+        subs.add(testEvent, 3, testToken, byStop, Date.now());
+        const reminders = subs.process(byStop, byVid, Date.now());
+        expect(reminders.reminder.size).toBe(0);
+    });
+
+    it('should only get removed by the remove method if explicitly targeted', () => {
+        const subs = new t.ReminderSubscriptions();
+        subs.add(testEvent, 3, testToken, {}, Date.now());
+        subs.add(testEventDiffRt, 3, testToken, {}, Date.now());
+        subs.add(testEvent, 3, r.RegistrationToken("anotherToken"), {}, Date.now());
+        expect(subs.subscriptions.length).toBe(3);
+        subs.remove(testEvent, testToken);
+        expect(subs.subscriptions.length).toBe(2);
+    });
+
     it('should send at the stop notifications', () => {
+        // TODO
+        expect(false).toBe(true);
         // const subs = new t.ReminderSubscriptions
     });
 
     it('should send delayed notifications', () => {
         // TODO 
+        expect(false).toBe(true);
     });
 
     it('should send disappeared notifications', () => {
         // TODO
+        expect(false).toBe(true);
     });
 
     it('should override some delayed notifications', () => {
         // TODO
+        expect(false).toBe(true);
     });
 
     it('should override some disappeared notifications', () => {
         // TODO
+        expect(false).toBe(true);
     });
 
     it('should have reasonable performance', () => {
         // TODO
+        expect(false).toBe(true);
     });
 });
 

--- a/src/services/reminder.test.ts
+++ b/src/services/reminder.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+
+import * as r from "./reminder";
+import { testing as t } from "./reminder";
+import { Prediction } from '../state/transitState';
+import { sortPreds } from './graphBuilder';
+
+const testToken = r.RegistrationToken("token1");
+const testEvent = r.Event({ stpid: "stop1", rtid: "route1" });
+
+function createCaches(preds: Prediction[]): { byStop: Record<string, Prediction[]>, byVid: Record<string, Prediction[]> } {
+    const byStop: Record<string, Prediction[]> = {};
+    const byVid: Record<string, Prediction[]> = {};
+    for (const pred of preds) {
+        if (byStop[pred.stpid] === undefined) {
+            byStop[pred.stpid] = [];
+        }
+        if (byVid[pred.vid] === undefined) {
+            byVid[pred.vid] = [];
+        }
+        byStop[pred.stpid].push(pred);
+        byVid[pred.vid].push(pred);
+    }
+    sortPreds(byStop);
+    sortPreds(byVid);
+    return { byStop, byVid };
+}
+
+describe('Reminders', () => {
+    it('should not send a threshold immediately and should move to next stage after sending', () => {
+        const subs = new t.ReminderSubscriptions();
+        const { byStop, byVid } = createCaches([
+            { rt: testEvent.rtid, vid: "vid1", stpid: testEvent.stpid, prdtm: Date.now() + 2 * 60 * 1000, prdctdn: "2" }
+        ]);
+        subs.add(testEvent, 3, testToken, byStop, Date.now());
+        // reminder should not trigger since the bus arrives too soon, simulate processing happening rougly a minute
+        // later
+        const reminders = subs.process(byStop, byVid, Date.now() + 60 * 1000);
+        console.log(byStop);
+        console.log(byVid);
+        console.log(reminders);
+        expect(reminders.reminder.size).toBe(0);
+        expect(reminders.atTheStop.size).toBe(0);
+        expect(reminders.delayed.size).toBe(0);
+        expect(reminders.disappeared.size).toBe(0);
+
+        // a later arriving bus where it should trigger
+        const { byStop: byStopLater, byVid: byVidLater } = createCaches([
+            { rt: testEvent.rtid, vid: "vid1", stpid: testEvent.stpid, prdtm: Date.now() + 4 * 60 * 1000, prdctdn: "2" }
+        ]);
+        const remindersLater = subs.process(byStopLater, byVidLater, Date.now() + 60 * 1000);
+        console.log(remindersLater);
+        expect(remindersLater.reminder.size).toBe(1);
+        expect(remindersLater.reminder.get(r.EventKey(testEvent))?.has(testToken));
+
+        expect(subs.activeRemindersFor(testToken).length).toBe(1);
+        expect(t.eventsEqual(subs.activeRemindersFor(testToken)[0].event, testEvent)).toBe(true);
+        expect(subs.activeRemindersFor(testToken)[0].stage).toBe(1);
+    });
+
+    it('should not send a disappeared notification if there never was a bus in the first place', () => {
+        const subs = new t.ReminderSubscriptions();
+        // the subscription gets added with no possible candidate vid
+        subs.add(testEvent, 3, testToken, {}, Date.now());
+        // will it trigger a disappeared reminder?
+        const reminders = subs.process({}, {}, Date.now());
+        expect(reminders.disappeared.size).toBe(0);
+    });
+
+    it('should send at the stop notifications', () => {
+        // const subs = new t.ReminderSubscriptions
+    });
+
+    it('should send delayed notifications', () => {
+        // TODO 
+    });
+
+    it('should send disappeared notifications', () => {
+        // TODO
+    });
+
+    it('should override some delayed notifications', () => {
+        // TODO
+    });
+
+    it('should override some disappeared notifications', () => {
+        // TODO
+    });
+
+    it('should have reasonable performance', () => {
+        // TODO
+    });
+});
+

--- a/src/services/reminder.test.ts
+++ b/src/services/reminder.test.ts
@@ -124,7 +124,7 @@ describe('Reminders', () => {
 
     it('should send disappeared notifications (stage 0)', () => {
         const subs = new t.ReminderSubscriptions();
-        const { byStop, byVid: _ } = createCaches([
+        const { byStop } = createCaches([
             { rt: testEvent.rtid, vid: "vid1", stpid: testEvent.stpid, prdtm: Date.now() + 4 * 60 * 1000, prdctdn: "4" }
         ]);
         subs.add(testEvent, 3, testToken, byStop, Date.now());

--- a/src/services/reminder.ts
+++ b/src/services/reminder.ts
@@ -290,14 +290,6 @@ class ReminderSubscriptions {
         return notifications;
     }
 
-    /** removes all subscriptions involving `event` */
-    removeAllFor(event: BaseEvent) {
-        this.subscriptions = this.subscriptions
-            .filter((s) => {
-                return eventsEqual(event, s.subscription.event);
-            });
-    }
-
     swapToken(from: RegistrationToken, to: RegistrationToken) {
         this.subscriptions = this.subscriptions.map((s) => {
             if (s.token === from) {
@@ -314,10 +306,6 @@ class ReminderSubscriptions {
             .map((s) => {
                 return s.subscription;
             });
-    }
-
-    describe() {
-        console.log(`There are ${this.subscriptions.length} reminder subscriptions`);
     }
 }
 

--- a/src/services/reminder.ts
+++ b/src/services/reminder.ts
@@ -3,52 +3,22 @@ import { getMessaging } from "firebase-admin/messaging";
 import { applicationDefault, initializeApp } from "firebase-admin/app";
 
 import * as state from "@/state/transitState";
+import { BaseEvent, DelayEvent, eventsEqual, toKey, Key, RegistrationToken, ThresholdEvent, fromKey, delayEvent, thresholdEvent } from "./reminderTypes";
+
+export * from "./reminderTypes";
 
 dotenv.config()
 
 // Initialize Firebase
 initializeApp({ credential: applicationDefault() });
 
-export type Event = {
-    stpid: string,
-    rtid: string,
-    readonly __brand: "event"
-}
-
-/** constructor */
-export function Event(x: { stpid: string, rtid: string }): Event {
-    return x as Event;
-}
-
-function eventsEqual(e1: Event, e2: Event): boolean {
-    return e1.stpid === e2.stpid && e1.rtid === e2.rtid;
-}
-
-export type RegistrationToken = string & { readonly __brand: "registration_token" }
-
-export function RegistrationToken(x: string): RegistrationToken {
-    return x as RegistrationToken;
-}
-
-export type EventKey = string & { readonly __brand: "event_key" }
-
-/** constructor */
-export function EventKey(e: Event): EventKey {
-    return `${e.stpid}|${e.rtid}` as EventKey;
-}
-
-function decodeEvent(e: EventKey): Event {
-    const split = e.split('|');
-    return Event({ stpid: split[0], rtid: split[1] });
-}
-
 /** Waiting for a prediction of the right `event` to have a arrival timestamp that is at or after `mustBeAfter` and an
  *  arrival time less than `thresh`. A bus is xx minutes from the stop notification is then sent. To handle delayed and
  *  disappeared notifications, a `candidateVid` is set to the soonest arriving bus that arrives after `mustbeAfter`.
  */
-type PreThreshold = {
+export type PreThreshold = {
     stage: 0,
-    event: Event,
+    event: BaseEvent,
     /** minutes */
     thresh: number,
     /** unix epoch milliseconds */
@@ -60,8 +30,8 @@ type PreThreshold = {
     candidateVidPredPrev: number | null
 };
 
-/** constructor */
-function PreThreshold(event: Event, thresh: number, candidateVid: string | null, now: number): PreThreshold {
+/** factory */
+function preThreshold(event: BaseEvent, thresh: number, candidateVid: string | null, now: number): PreThreshold {
     return {
         stage: 0, event, thresh, mustBeAfter: now + thresh * 60 * 1000, candidateVid, candidateVidPredPrev: null
     };
@@ -77,10 +47,10 @@ function firstPredAfter(timestamp: number, preds: state.Prediction[]): state.Pre
 /** Waiting for the bus indicated by `vid` to be at the stop indicated by `stpid`. Logic for what notification to send
  *  is complicated by arrival times sometimes skipping DUE, see `ReminderSubscriptons.process` for details.
  */
-type PostThreshold = { stage: 1, event: Event, vid: string, vidPredPrev: number | null };
+export type PostThreshold = { stage: 1, event: BaseEvent, vid: string, vidPredPrev: number | null };
 
-/** constructor */
-function PostThreshold(prev: PreThreshold, vid: string): PostThreshold {
+/** factory */
+function postThreshold(prev: PreThreshold, vid: string): PostThreshold {
     return {
         stage: 1, event: prev.event, vid, vidPredPrev: prev.candidateVid === vid ? prev.candidateVidPredPrev : null
     };
@@ -89,6 +59,19 @@ function PostThreshold(prev: PreThreshold, vid: string): PostThreshold {
 function prdctdnToNum(prdctdn: string): number {
     return prdctdn === 'DUE' ? 1 : parseInt(prdctdn);
 }
+
+/** result of ReminderSubscriptons.process */
+type RemindersToTrigger = {
+    /** can be sent in bulk based off of route, stop, and threshold (or route, stop, and prdctdn) */
+    reminder: Map<Key<ThresholdEvent>, Set<RegistrationToken>>,
+    /** can be sent in bulk based off of what route and stop */
+    atTheStop: Map<Key<BaseEvent>, Set<RegistrationToken>>,
+    /** can be sent in bulk based off of route and stop */
+    disappeared: Map<Key<BaseEvent>, Set<RegistrationToken>>,
+    /** can be sent in bulk based off of route, stop, delay amount, arrival time (or vid?) */
+    delayed: Map<Key<DelayEvent>, Set<RegistrationToken>>,
+    updated: Set<RegistrationToken>
+}; 
 
 /** Subscriptions go through a pipeline, see types above for details. */
 class ReminderSubscriptions {
@@ -103,10 +86,10 @@ class ReminderSubscriptions {
     /** Adds a new subscription, uses prediction data to determine a candidate vid.
         REQUIRES: `predsByStopId` has predictions sorted by arrival timestamp
     */
-    add(event: Event, thresh: number, token: RegistrationToken, predsByStopId: Record<string, state.Prediction[]>, now: number) {
+    add(event: BaseEvent, thresh: number, token: RegistrationToken, predsByStopId: Record<string, state.Prediction[]>, now: number) {
         console.log("Adding a reminder subscription");
         const predictions = predsByStopId[event.stpid];
-        const subscription = PreThreshold(event, thresh, null, now);
+        const subscription = preThreshold(event, thresh, null, now);
         if (predictions) {
             const relevant = predictions
                 .filter((p) => p.rt === event.rtid);
@@ -117,7 +100,7 @@ class ReminderSubscriptions {
     }
 
     /** removes all subscriptions that involve both `event` and `token` */
-    remove(event: Event, token: RegistrationToken) {
+    remove(event: BaseEvent, token: RegistrationToken) {
         console.log("Removing a reminder subscription");
         this.subscriptions = this.subscriptions
             .filter((s) => s.token != token || !eventsEqual(s.subscription.event, event))
@@ -146,23 +129,17 @@ class ReminderSubscriptions {
     process(
         predsByStopId: Record<string, state.Prediction[] | undefined>,
         predsByVid: Record<string, state.Prediction[] | undefined>,
-        now: number
-    ): {
-        reminder: Map<EventKey, Set<RegistrationToken>>,
-        atTheStop: Map<EventKey, Set<RegistrationToken>>,
-        disappeared: Map<EventKey, Set<RegistrationToken>>,
-        delayed: Map<EventKey, Set<RegistrationToken>>,
-        updated: Set<RegistrationToken>
-    } {
-        const addHelper = (map: Map<EventKey, Set<RegistrationToken>>, key: EventKey, token: RegistrationToken) => {
+        now: number,
+    ): RemindersToTrigger {
+        const addHelper = <K, T>(map: Map<Key<K>, Set<T>>, key: Key<K>, contents: T) => {
             let tokens = map.get(key);
             if (tokens === undefined) {
                 map.set(key, new Set());
                 tokens = map.get(key)!;
             }
-            tokens.add(token);
+            tokens.add(contents);
         };
-        const notifications = {
+        const notifications: RemindersToTrigger = {
             reminder: new Map(),
             atTheStop: new Map(),
             disappeared: new Map(),
@@ -170,17 +147,15 @@ class ReminderSubscriptions {
             updated: new Set<RegistrationToken>()
         };
 
-        // TODO: send time update messages
-
         const newSubscriptions: typeof this.subscriptions = [];
         for (const s of this.subscriptions) {
-            const key = EventKey(s.subscription.event);
-
             // only one is sent, variable order is priority
-            let disappeared = false;
-            let delayed = false;
-            let threshold = false;
-            let ats = false;
+            let disappeared: BaseEvent | null = null;
+            let delayed: DelayEvent | null = null;
+            let threshold: ThresholdEvent | null = null;
+            let ats: BaseEvent | null = null;
+
+            let timeChanged = false;
 
             if (s.subscription.stage === 0) {
                 // did the candidate vehicle change?
@@ -192,10 +167,13 @@ class ReminderSubscriptions {
                 if (newCandidate === null) {
                     if (s.subscription.candidateVid !== null) {
                         // no candidate now + existed before
-                        disappeared = true;
+                        disappeared = s.subscription.event;
                     }
                 } else {
                     const pred = prdctdnToNum(newCandidate.prdctdn);
+                    if (s.subscription.candidateVidPredPrev !== pred) {
+                        timeChanged = true;
+                    }
                     if (newCandidate.vid !== s.subscription.candidateVid) {
                         // new candidate
                         console.log(`stage 0: new candidate, time is now ${pred}`);
@@ -208,11 +186,13 @@ class ReminderSubscriptions {
                         && pred > s.subscription.candidateVidPredPrev
                     ) {
                         // delayed
-                        delayed = true;
+                        delayed = delayEvent(
+                            { ...s.subscription.event, prevPred: s.subscription.candidateVidPredPrev, currPred: pred }
+                        );
                     }
                     s.subscription.candidateVidPredPrev = pred;
                     if (newCandidate.prdtm > s.subscription.mustBeAfter && pred <= s.subscription.thresh) {
-                        threshold = true;
+                        threshold = thresholdEvent({ ...s.subscription.event, threshold: s.subscription.thresh })
                     }
                 }
             } else {
@@ -231,20 +211,23 @@ class ReminderSubscriptions {
 
                 console.log(`stage 1: time is now ${currArrivalTime}`);
 
+                if (currArrivalTime !== prevArrivalTime) {
+                    timeChanged = true;
+                }
                 if (currArrivalTime === null) {
                     // disappeared
                     if (prevArrivalTime !== null && prevArrivalTime <= shouldBeArrivingThresh
                     ) {
                         // override
                         console.log("disappeared notification was overriden!");
-                        ats = true;
+                        ats = s.subscription.event;
                     } else {
                         console.log("disappeared notification!");
-                        disappeared = true;
+                        disappeared = s.subscription.event;
                     }
                 } else if (currArrivalTime === 1) {
                     // at the stop
-                    ats = true;
+                    ats = s.subscription.event;
                 } else if (prevArrivalTime !== null && currArrivalTime > prevArrivalTime) {
                     // delayed
                     if (prevArrivalTime <= shouldBeArrivingThresh
@@ -252,22 +235,28 @@ class ReminderSubscriptions {
                     ) {
                         // override
                         console.log("delayed notification was overriden!");
-                        ats = true;
+                        ats = s.subscription.event;
                     } else {
                         console.log("delayed notification!");
-                        delayed = true;
+                        delayed = delayEvent(
+                            { ...s.subscription.event, prevPred: prevArrivalTime, currPred: currArrivalTime }
+                        );
                     }
                 }
                 s.subscription.vidPredPrev = currArrivalTime;
             }
 
+            if (disappeared || delayed|| threshold || ats || delayed || timeChanged) {
+                notifications.updated.add(s.token);
+            }
+
             if (disappeared) {
-                addHelper(notifications.disappeared, key, s.token);
+                addHelper(notifications.disappeared, toKey(disappeared), s.token);
             } else if (delayed) {
-                addHelper(notifications.delayed, key, s.token);
+                addHelper(notifications.delayed, toKey(delayed), s.token);
                 newSubscriptions.push(s);
             } else if (threshold) {
-                addHelper(notifications.reminder, key, s.token);
+                addHelper(notifications.reminder, toKey(threshold), s.token);
                 if (s.subscription.stage !== 0) {
                     throw Error("A PostTheshold subscription tried to trigger a threshold notification");
                 }
@@ -275,10 +264,10 @@ class ReminderSubscriptions {
                     throw Error("A threshold notification was triggered without a corresponding vid");
                 }
                 newSubscriptions.push(
-                    { token: s.token, subscription: PostThreshold(s.subscription, s.subscription.candidateVid) }
+                    { token: s.token, subscription: postThreshold(s.subscription, s.subscription.candidateVid) }
                 );
             } else if (ats) {
-                addHelper(notifications.atTheStop, key, s.token);
+                addHelper(notifications.atTheStop, toKey(ats), s.token);
             } else {
                 newSubscriptions.push(s);
             }
@@ -300,7 +289,7 @@ class ReminderSubscriptions {
     }
 
     /** removes all subscriptions involving `event` */
-    removeAllFor(event: Event) {
+    removeAllFor(event: BaseEvent) {
         this.subscriptions = this.subscriptions
             .filter((s) => {
                 return eventsEqual(event, s.subscription.event);
@@ -358,18 +347,18 @@ function processRemindersHelper(
 ) {
     const notifications = reminderSubscriptions.process(predsByStopId, predsByVid, Date.now());
     for (const [eventKey, tokens] of notifications.reminder) {
-        const event = decodeEvent(eventKey);
+        const event = fromKey(eventKey);
         const stopName = state.stopIdToName[event.stpid] ?? event.stpid;;
         sendNotifToAll(
             {
                 title: 'Bus Arrival Reminder',
-                body: `${event.rtid} is ${"TODO"} minute(s) away from ${stopName}`
+                body: `${event.rtid} is less than ${event.threshold} minute(s) away from ${stopName}`
             },
             tokens
         );
     }
     for (const [eventKey, tokens] of notifications.atTheStop) {
-        const event = decodeEvent(eventKey);
+        const event = fromKey(eventKey);
         const stopName = state.stopIdToName[event.stpid] ?? event.stpid;;
         sendToAll(
             {
@@ -379,21 +368,19 @@ function processRemindersHelper(
         );
     }
     for (const [eventKey, tokens] of notifications.delayed) {
-        const event = decodeEvent(eventKey);
+        const event = fromKey(eventKey);
         const stopName = state.stopIdToName[event.stpid] ?? event.stpid;;
-        // const arrivalTime = arrivalTimes.get(eventKey);
-        // const delay = arrivalTime?.curr !== null && arrivalTime?.prev ? `${arrivalTime.curr - arrivalTime.prev}` : `some`;
         sendNotifToAll(
             {
                 title: `Bus Delayed`,
-                body: `The ${event.rtid} bus en route to ${stopName} got delayed by ${"TODO"} minute(s). `
-                    + `New time is ${"TODO"} minute(s).`
+                body: `The ${event.rtid} bus en route to ${stopName} got delayed by ${event.currPred - event.prevPred}`
+                    + `minute(s). New time is ${event.currPred} minute(s).`
             },
             tokens
         );
     }
     for (const [eventKey, tokens] of notifications.disappeared) {
-        const event = decodeEvent(eventKey);
+        const event = fromKey(eventKey);
         const stopName = state.stopIdToName[event.stpid] ?? event.stpid;;
         sendNotifToAll(
             {

--- a/src/services/reminder.ts
+++ b/src/services/reminder.ts
@@ -1,8 +1,8 @@
-
 import dotenv from "dotenv";
-import * as state from "../state/transitState";
 import { getMessaging } from "firebase-admin/messaging";
 import { applicationDefault, initializeApp } from "firebase-admin/app";
+
+import * as state from "@/state/transitState";
 
 dotenv.config()
 
@@ -17,6 +17,10 @@ type Event = {
 
 function Event(x: { stpid: string, rtid: string }): Event {
     return x as Event;
+}
+
+function eventsEqual(e1: Event, e2: Event): boolean {
+    return e1.stpid === e2.stpid && e1.rtid === e2.rtid;
 }
 
 type RegistrationToken = string & { readonly __brand: "registration_token" }
@@ -40,48 +44,108 @@ function decodeEvent(e: EventKey): Event {
  *  arrival time less than `thresh`. A bus is xx minutes from the stop notification is then sent. To handle delayed and
  *  disappeared notifications, a `candidateVid` is set to the soonest arriving bus that arrives after `mustbeAfter`.
  */
-type SubscriptionPreThreshold = {
+type PreThreshold = {
     stage: 0,
     event: Event,
+    /** minutes */
     thresh: number,
+    /** unix epoch milliseconds */
     mustBeAfter: number,
-    candidateVid: string,
+    /** stores the bus that'll likely trigger the threshold notification, being only a candidate this can change
+    as things are updated and such a change won't trigger a disappeared notification */
+    candidateVid: string | null,
+    /** minutes */
     candidateVidPredPrev: number | null
 };
+
+/** constructor */
+function PreThreshold(event: Event, thresh: number, candidateVid: string | null, now: number): PreThreshold {
+    return {
+        stage: 0, event, thresh, mustBeAfter: now + thresh * 60 * 1000, candidateVid, candidateVidPredPrev: null
+    };
+}
+
+/** Finds the earlies prediction that is after 'mustBeAfter'
+ *  REQUIRES: `preds` is sorted ascending by `prdtm`
+ */
+function firstPredAfter(timestamp: number, preds: state.Prediction[]): state.Prediction | null {
+    return preds.find((p) => p.prdtm > timestamp) ?? null;
+}
+
 /** Waiting for the bus indicated by `vid` to be at the stop indicated by `stpid`. Logic for what notification to send
  *  is complicated by arrival times sometimes skipping DUE, see `ReminderSubscriptons.process` for details.
  */
-type SubscriptionPostThreshold = { stage: 1, stpid: string, vid: string, vidPredPrev: number | null };
+type PostThreshold = { stage: 1, event: Event, vid: string, vidPredPrev: number | null };
+
+/** constructor */
+function PostThreshold(prev: PreThreshold, vid: string): PostThreshold {
+    return {
+        stage: 1, event: prev.event, vid, vidPredPrev: prev.candidateVid === vid ? prev.candidateVidPredPrev : null
+    };
+}
+
+function prdctdnToNum(prdctdn: string): number {
+    return prdctdn === 'DUE' ? 1 : parseInt(prdctdn);
+}
 
 /** Subscriptions go through a pipeline, see types above for details. */
 class ReminderSubscriptions {
-    // a thresh of null means being in the second stage
     subscriptions: Array<{
-        token: RegistrationToken, subscription: SubscriptionPreThreshold | SubscriptionPostThreshold
+        token: RegistrationToken, subscription: PreThreshold | PostThreshold
     }>
 
     constructor() {
         this.subscriptions = [];
     }
 
-    // addition is done to the start of the pipeline
-    add(event: Event, thresh: number, token: RegistrationToken) {
+    /** Adds a new subscription, uses prediction data to determine a candidate vid.
+        REQUIRES: `predsByStopId` has predictions sorted by arrival timestamp
+    */
+    add(event: Event, thresh: number, token: RegistrationToken, predsByStopId: Record<string, state.Prediction[]>, now: number) {
         console.log("Adding a reminder subscription");
-        this.subscriptions.push({ event, thresh, token });
+        const predictions = predsByStopId[event.stpid];
+        const subscription = PreThreshold(event, thresh, null, now);
+        if (predictions) {
+            const relevant = predictions
+                .filter((p) => p.rt === event.rtid);
+            subscription.candidateVid = firstPredAfter(subscription.mustBeAfter, relevant)?.vid ?? null;
+        }
+        this.subscriptions.push({ token, subscription });
         sendReminderUpdateToAll(new Set([token]));
     }
 
-    // removes all subscriptions involving both `event` and `token`
+    /** removes all subscriptions that involve both `event` and `token` */
     remove(event: Event, token: RegistrationToken) {
         console.log("Removing a reminder subscription");
         this.subscriptions = this.subscriptions
-            .filter((s) => s.event.rtid !== event.rtid || s.event.stpid !== event.stpid || s.token !== token);
+            .filter((s) => s.token != token || !eventsEqual(s.subscription.event, event))
         sendReminderUpdateToAll(new Set([token]));
     }
 
-    // updates the status of all registrations, returning an object representing the
-    // notifications that should be sent
-    process(arrivalTimes: Map<EventKey, { curr: number | null, prev: number | null }>): {
+    /**  updates the status of all registrations, returning an object representing the
+        notifications that should be sent
+
+         - threshold reminders are sent only for subscriptions of `PreThreshold`, and trigger when the candidate
+         vehicle has an arrival time at or under `thresh` and an arrival timestamp after `mustBeAfter`
+         - at the stop reminders are sent only for subscriptions of `PostThreshold` and trigger when the tracked
+         vehicle has a `pred` of 1/0 or if `pred` becomes `null` and `vidPredPrev <= shouldBeArrivingThresh`
+         - disappeared reminders are sent in both stages
+             - stage 0 if there no longer is a valid `candidateVid`
+             - stage 1 if the relevant `pred` of the tracked vehicle becomes `null` and the the bus isn't too close to
+             the stop
+        - delayed reminders are sent in both stages
+            - stage 0 if the relevant `pred` of the candidate vehicle increases (can also happen from the candidate
+            vehicle changing)
+            - stage 1 if the relevant `pred` goes up and it doesn't seem like the bus going past the stop (this is
+            still relevant even when tracking a specific vehicle if routes loop back on themselves weirdly)
+
+        REQUIRES: `predsByStopId` and `predsByVid` have predictions sorted by arrival timestamp
+      */
+    process(
+        predsByStopId: Record<string, state.Prediction[] | undefined>,
+        predsByVid: Record<string, state.Prediction[] | undefined>,
+        now: number
+    ): {
         reminder: Map<EventKey, Set<RegistrationToken>>,
         atTheStop: Map<EventKey, Set<RegistrationToken>>,
         disappeared: Map<EventKey, Set<RegistrationToken>>,
@@ -104,77 +168,123 @@ class ReminderSubscriptions {
             updated: new Set<RegistrationToken>()
         };
 
+        // TODO: send time update messages
+
         const newSubscriptions: typeof this.subscriptions = [];
-        for (const subscription of this.subscriptions) {
-            const key = EventKey(subscription.event);
-            const arrivalTime = arrivalTimes.get(key);
-            if (arrivalTime !== undefined && arrivalTime.curr !== arrivalTime.prev) {
-                notifications.updated.add(subscription.token);
+        for (const s of this.subscriptions) {
+            const key = EventKey(s.subscription.event);
+
+            // only one is sent, variable order is priority
+            let disappeared = false;
+            let delayed = false;
+            let threshold = false;
+            let ats = false;
+
+            if (s.subscription.stage === 0) {
+                // did the candidate vehicle change?
+                // PERF: caching these filter results might be good
+                const newCandidate = firstPredAfter(
+                    s.subscription.mustBeAfter,
+                    (predsByStopId[s.subscription.event.stpid] ?? []).filter((p) => p.rt === s.subscription.event.rtid)
+                );
+                if (newCandidate === null) {
+                    // no candidate
+                    disappeared = true;
+                } else {
+                    const pred = prdctdnToNum(newCandidate.prdctdn);
+                    if (newCandidate.vid !== s.subscription.candidateVid) {
+                        // new candidate
+                        console.log(`stage 0: new candidate, time is now ${pred}`);
+                        s.subscription.candidateVid = newCandidate.vid;
+                    } else {
+                        // same candidate
+                        console.log(`stage 0: same candidate, time is now ${pred}`);
+                    }
+                    if (s.subscription.candidateVidPredPrev !== null
+                        && pred > s.subscription.candidateVidPredPrev
+                    ) {
+                        // delayed
+                        delayed = true;
+                    }
+                    s.subscription.candidateVidPredPrev = pred;
+                    if (newCandidate.prdtm > s.subscription.mustBeAfter && pred <= s.subscription.thresh) {
+                        threshold = true;
+                    }
+                }
+            } else {
+                // There might be times where the prediction of the bus skips past DUE/1, which results in a
+                // disappeared or delayed notification when there really shouldn't be. `shouldBeArrivingThresh`
+                // overrides a bus disappeared notification with an at the stop one if the arrival time is at or below
+                // it. It also overrides a delayed notification if the delay amount is more than
+                // `maxDelayWhenShouldBeArriving`
+                const shouldBeArrivingThresh = 3;
+                const maxDelayWhenShouldBeArriving = 1;
+
+                const prdctdn = (predsByVid[s.subscription.vid] ?? [])
+                    .find((p) => p.stpid === s.subscription.event.stpid)?.prdctdn ?? null;
+                const currArrivalTime = prdctdn == null ? null : prdctdnToNum(prdctdn);
+                const prevArrivalTime = s.subscription.vidPredPrev;
+
+                console.log(`stage 1: time is now ${currArrivalTime}`);
+
+                if (currArrivalTime === null) {
+                    // disappeared
+                    if (prevArrivalTime !== null && prevArrivalTime <= shouldBeArrivingThresh
+                    ) {
+                        // override
+                        console.log("disappeared notification was overriden!");
+                        ats = true;
+                    } else {
+                        console.log("disappeared notification!");
+                        disappeared = true;
+                    }
+                } else if (currArrivalTime === 1) {
+                    // at the stop
+                    ats = true;
+                } else if (prevArrivalTime !== null && currArrivalTime > prevArrivalTime) {
+                    // delayed
+                    if (prevArrivalTime <= shouldBeArrivingThresh
+                        && currArrivalTime - prevArrivalTime > maxDelayWhenShouldBeArriving
+                    ) {
+                        // override
+                        console.log("delayed notification was overriden!");
+                        ats = true;
+                    } else {
+                        console.log("delayed notification!");
+                        delayed = true;
+                    }
+                }
+                s.subscription.vidPredPrev = currArrivalTime;
             }
 
-            const logInfo = () => {
-                console.log(`process() is operating on ${key}...`);
-                console.log(`the arrival time is ${JSON.stringify(arrivalTime)}`);
-                console.log(`subscription is for ${JSON.stringify(subscription.event)} @ ${subscription.thresh}`);
-            };
-
-            // There might be times where the prediction of the bus skips past DUE/1, which results in a disappeared or
-            // delayed notification when there really shouldn't be. 
-            // `shouldBeArrivingThresh` overrides a bus disappeared notification with an at the stop one if the arrival
-            // time is at or below it. It also overrides a delayed notification if the delay amount is more than
-            // `maxDelayWhenShouldBeArriving`
-            const shouldBeArrivingThresh = 3;
-            const maxDelayWhenShouldBeArriving = 1;
-
-            if (arrivalTime === undefined || arrivalTime.curr === null) {
-                // disappeared
-                if (arrivalTime !== undefined
-                    && arrivalTime.prev !== null
-                    && arrivalTime.prev <= shouldBeArrivingThresh
-                ) {
-                    // override
-                    console.log("disappeared notification was overriden!");
-                    addHelper(notifications.atTheStop, key, subscription.token);
-                    logInfo();
-                } else {
-                    console.log("disappeared notification!");
-                    addHelper(notifications.disappeared, key, subscription.token);
-                    logInfo();
+            if (disappeared) {
+                addHelper(notifications.disappeared, key, s.token);
+            } else if (delayed) {
+                addHelper(notifications.delayed, key, s.token);
+                newSubscriptions.push(s);
+            } else if (threshold) {
+                addHelper(notifications.reminder, key, s.token);
+                if (s.subscription.stage !== 0) {
+                    throw Error("A PostTheshold subscription tried to trigger a threshold notification");
                 }
-            } else if (arrivalTime.curr === 1) {
-                // at the stop
-                addHelper(notifications.atTheStop, key, subscription.token);
-                logInfo();
-            } else if (arrivalTime.prev !== null && arrivalTime.curr > arrivalTime.prev) {
-                // delayed
-                if (arrivalTime.prev <= shouldBeArrivingThresh
-                    && arrivalTime.curr - arrivalTime.prev > maxDelayWhenShouldBeArriving
-                ) {
-                    // override
-                    console.log("delayed notification was overriden!");
-                    addHelper(notifications.atTheStop, key, subscription.token);
-                    logInfo();
-                } else {
-                    console.log("delayed notification!");
-                    addHelper(notifications.delayed, key, subscription.token);
-                    newSubscriptions.push(subscription);  // keep subscription if delayed but not if overriden
-                    logInfo();
+                if (s.subscription.candidateVid === null) {
+                    throw Error("A threshold notification was triggered without a corresponding vid");
                 }
-            } else if (subscription.thresh !== null
-                && arrivalTime.curr <= subscription.thresh
-            ) {
-                console.log("reminder notification");
-                // reminder
-                addHelper(notifications.reminder, key, subscription.token);
-                // replace with next in pipeline, a subscription to bus at stop
-                newSubscriptions.push({ event: subscription.event, thresh: null, token: subscription.token });
-                logInfo();
+                newSubscriptions.push(
+                    { token: s.token, subscription: PostThreshold(s.subscription, s.subscription.candidateVid) }
+                );
+            } else if (ats) {
+                addHelper(notifications.atTheStop, key, s.token);
             } else {
-                newSubscriptions.push(subscription);  // keep subscription by default
+                newSubscriptions.push(s);
             }
         }
         this.subscriptions = newSubscriptions;
-        if (notifications.reminder.size !== 0 || notifications.atTheStop.size !== 0 || notifications.delayed.size !== 0 || notifications.disappeared.size !== 0) {
+        if (notifications.reminder.size !== 0
+            || notifications.atTheStop.size !== 0
+            || notifications.delayed.size !== 0
+            || notifications.disappeared.size !== 0
+        ) {
             console.log(
                 `Process completed with ${notifications.reminder.size} threshold reminders, `
                 + `${notifications.atTheStop.size} at the stop reminders, `
@@ -185,10 +295,12 @@ class ReminderSubscriptions {
         return notifications;
     }
 
-    // removes all subscriptions involving `event`
+    /** removes all subscriptions involving `event` */
     removeAllFor(event: Event) {
         this.subscriptions = this.subscriptions
-            .filter((s) => s.event.rtid !== event.rtid || s.event.stpid !== event.stpid);
+            .filter((s) => {
+                return eventsEqual(event, s.subscription.event);
+            });
     }
 
     swapToken(from: RegistrationToken, to: RegistrationToken) {
@@ -201,21 +313,11 @@ class ReminderSubscriptions {
         });
     }
 
-    activeRemindersFor(id: RegistrationToken): Array<{
-        stpid: string,
-        rtid: string,
-        thresh: number | null,
-        eta: number | null
-    }> {
+    activeRemindersFor(id: RegistrationToken): Array<PreThreshold | PostThreshold> {
         return this.subscriptions
             .filter((s) => s.token === id)
             .map((s) => {
-                return {
-                    stpid: s.event.stpid,
-                    rtid: s.event.rtid,
-                    thresh: s.thresh,
-                    eta: arrivalTimes.get(EventKey(s.event))?.curr ?? null
-                };
+                return s.subscription;
             });
     }
 
@@ -224,88 +326,36 @@ class ReminderSubscriptions {
     }
 }
 
-const reminderSubscriptions = new ReminderSubscriptions();
+const universityReminderSubscriptions = new ReminderSubscriptions();
 
-function processReminders() {
-    // move current arrival times to prev
-    for (const [_k, v] of arrivalTimes) {
-        v.prev = v.curr;
-        v.curr = null;
+function processUniversityReminders() {
+    try {
+        processRemindersHelper(state.cachedPredsByStopId, state.cachedPredsByVid);
+    } catch (e) {
+        console.log("Processing university reminders failed");
+        console.log(`${JSON.stringify(e)}`);
     }
+}
 
-    // determine arrival time updates for each stop
-    for (const stpid of Object.keys(state.cachedPredsByStopId)) {
-        for (const vehicle of state.cachedPredsByStopId[stpid]) {
-            const rtid = vehicle.rt;
-            if (typeof rtid !== "string") {
-                console.log("prediction found that is missing rtid!");
-                continue;
-            }
-            const prediction = vehicle.prdctdn === 'DUE' ? 1 : parseInt(vehicle.prdctdn);
-            const key = EventKey(Event({ stpid: stpid, rtid: rtid }));
-            let time = arrivalTimes.get(key);
-            if (time === undefined) {
-                arrivalTimes.set(key, { curr: null, prev: null });
-                time = arrivalTimes.get(key)!;
-            }
-            if (time.curr === null || prediction < time.curr)
-                time.curr = prediction;
-        }
-    }
-    // also do the ride
-    for (const stpid of Object.keys(state.cachedRidePredsByStopId)) {
-        for (const vehicle of state.cachedRidePredsByStopId[stpid]) {
-            const rtid = vehicle.rt;
-            if (typeof rtid !== "string") {
-                console.log("prediction found that is missing rtid!");
-                continue;
-            }
-            const prediction = vehicle.prdctdn === 'DUE' ? 1 : parseInt(vehicle.prdctdn);
-            const key = EventKey(Event({ stpid: stpid, rtid: rtid }));
-            let time = arrivalTimes.get(key);
-            if (time === undefined) {
-                arrivalTimes.set(key, { curr: null, prev: null });
-                time = arrivalTimes.get(key)!;
-            }
-            if (time.curr === null || prediction < time.curr)
-                time.curr = prediction;
-        }
-    }
-
-    const keys = new Set<EventKey>();
-    for (const event of reminderSubscriptions.subscriptions) {
-        const key = EventKey(event.event);
-        keys.add(key);
-    }
-    let didLogHeader = false;
-    for (const key of keys) {
-        const arrivalTime = arrivalTimes.get(key);
-        if (arrivalTime?.curr == arrivalTime?.prev) {
-            continue;
-        }
-        if (!didLogHeader) {
-            console.log("Arrival Times Information");
-            didLogHeader = true;
-        }
-        console.log(` - ${key}: c = ${arrivalTime?.curr} p = ${arrivalTime?.prev}`);
-    }
-
-    // send push notifications as needed
-    const notifications = reminderSubscriptions.process(arrivalTimes);
+function processRemindersHelper(
+    predsByStopId: Record<string, state.Prediction[] | undefined>,
+    predsByVid: Record<string, state.Prediction[] | undefined>
+) {
+    const notifications = universityReminderSubscriptions.process(predsByStopId, predsByVid, Date.now());
     for (const [eventKey, tokens] of notifications.reminder) {
         const event = decodeEvent(eventKey);
-        const stopName = state.stopIdToName[event.stpid] ?? event.stpid;
+        const stopName = state.stopIdToName[event.stpid] ?? event.stpid;;
         sendNotifToAll(
             {
                 title: 'Bus Arrival Reminder',
-                body: `${event.rtid} is ${arrivalTimes.get(eventKey)?.curr} minute(s) away from ${stopName}`
+                body: `${event.rtid} is ${"TODO"} minute(s) away from ${stopName}`
             },
             tokens
         );
     }
     for (const [eventKey, tokens] of notifications.atTheStop) {
         const event = decodeEvent(eventKey);
-        const stopName = state.stopIdToName[event.stpid] ?? event.stpid;
+        const stopName = state.stopIdToName[event.stpid] ?? event.stpid;;
         sendToAll(
             {
                 notification: { title: 'Bus Arriving', body: `${event.rtid} is almost at ${stopName}` },
@@ -315,21 +365,21 @@ function processReminders() {
     }
     for (const [eventKey, tokens] of notifications.delayed) {
         const event = decodeEvent(eventKey);
-        const stopName = state.stopIdToName[event.stpid] ?? event.stpid;
-        const arrivalTime = arrivalTimes.get(eventKey);
-        const delay = arrivalTime?.curr !== null && arrivalTime?.prev ? `${arrivalTime.curr - arrivalTime.prev}` : `some`;
+        const stopName = state.stopIdToName[event.stpid] ?? event.stpid;;
+        // const arrivalTime = arrivalTimes.get(eventKey);
+        // const delay = arrivalTime?.curr !== null && arrivalTime?.prev ? `${arrivalTime.curr - arrivalTime.prev}` : `some`;
         sendNotifToAll(
             {
                 title: `Bus Delayed`,
-                body: `The ${event.rtid} bus en route to ${stopName} got delayed by ${delay} minute(s). `
-                    + `New time is ${arrivalTime?.curr ?? 'unknown'} minute(s).`
+                body: `The ${event.rtid} bus en route to ${stopName} got delayed by ${"TODO"} minute(s). `
+                    + `New time is ${"TODO"} minute(s).`
             },
             tokens
         );
     }
     for (const [eventKey, tokens] of notifications.disappeared) {
         const event = decodeEvent(eventKey);
-        const stopName = state.stopIdToName[event.stpid] ?? event.stpid;
+        const stopName = state.stopIdToName[event.stpid] ?? event.stpid;;
         sendNotifToAll(
             {
                 title: `Bus Disappeared`,
@@ -393,4 +443,15 @@ function sendToAllHelper(msg: any, tokens: Set<string>) {
         });
 }
 
-export { processReminders, reminderSubscriptions, Event, EventKey, RegistrationToken, sendNotifToAll, arrivalTimes };
+/** exported for tests */
+export const testing = {
+    ReminderSubscriptions,
+    eventsEqual
+};
+
+export {
+    processUniversityReminders,
+    universityReminderSubscriptions,
+    sendNotifToAll,
+    Event, EventKey, RegistrationToken,
+};

--- a/src/services/reminder.ts
+++ b/src/services/reminder.ts
@@ -1,7 +1,6 @@
 
 import dotenv from "dotenv";
 import * as state from "../state/transitState";
-// import { cachedPredsByStopId, stopIdToName } from "./busService";
 import { getMessaging } from "firebase-admin/messaging";
 import { applicationDefault, initializeApp } from "firebase-admin/app";
 
@@ -37,13 +36,29 @@ function decodeEvent(e: EventKey): Event {
     return Event({ stpid: split[0], rtid: split[1] });
 }
 
-// Subscriptions go through a pipeline, starting in the waiting for reminder
-// stage. After the bus in x minutes notification is set they move to the
-// waiting for bus stage, where they stay until the bus is arriving notification
-// is sent. Being in the second stage is repsented by having a threshold of null.
+/** Waiting for a prediction of the right `event` to have a arrival timestamp that is at or after `mustBeAfter` and an
+ *  arrival time less than `thresh`. A bus is xx minutes from the stop notification is then sent. To handle delayed and
+ *  disappeared notifications, a `candidateVid` is set to the soonest arriving bus that arrives after `mustbeAfter`.
+ */
+type SubscriptionPreThreshold = {
+    stage: 0,
+    event: Event,
+    thresh: number,
+    mustBeAfter: number,
+    candidateVid: string,
+    candidateVidPredPrev: number | null
+};
+/** Waiting for the bus indicated by `vid` to be at the stop indicated by `stpid`. Logic for what notification to send
+ *  is complicated by arrival times sometimes skipping DUE, see `ReminderSubscriptons.process` for details.
+ */
+type SubscriptionPostThreshold = { stage: 1, stpid: string, vid: string, vidPredPrev: number | null };
+
+/** Subscriptions go through a pipeline, see types above for details. */
 class ReminderSubscriptions {
     // a thresh of null means being in the second stage
-    subscriptions: Array<{ event: Event, thresh: number | null, token: RegistrationToken }>
+    subscriptions: Array<{
+        token: RegistrationToken, subscription: SubscriptionPreThreshold | SubscriptionPostThreshold
+    }>
 
     constructor() {
         this.subscriptions = [];
@@ -210,7 +225,6 @@ class ReminderSubscriptions {
 }
 
 const reminderSubscriptions = new ReminderSubscriptions();
-const arrivalTimes: Map<EventKey, { curr: number | null, prev: number | null }> = new Map();
 
 function processReminders() {
     // move current arrival times to prev

--- a/src/services/reminder.ts
+++ b/src/services/reminder.ts
@@ -9,13 +9,14 @@ dotenv.config()
 // Initialize Firebase
 initializeApp({ credential: applicationDefault() });
 
-type Event = {
+export type Event = {
     stpid: string,
     rtid: string,
     readonly __brand: "event"
 }
 
-function Event(x: { stpid: string, rtid: string }): Event {
+/** constructor */
+export function Event(x: { stpid: string, rtid: string }): Event {
     return x as Event;
 }
 
@@ -23,15 +24,16 @@ function eventsEqual(e1: Event, e2: Event): boolean {
     return e1.stpid === e2.stpid && e1.rtid === e2.rtid;
 }
 
-type RegistrationToken = string & { readonly __brand: "registration_token" }
+export type RegistrationToken = string & { readonly __brand: "registration_token" }
 
-function RegistrationToken(x: string): RegistrationToken {
+export function RegistrationToken(x: string): RegistrationToken {
     return x as RegistrationToken;
 }
 
-type EventKey = string & { readonly __brand: "event_key" }
+export type EventKey = string & { readonly __brand: "event_key" }
 
-function EventKey(e: Event): EventKey {
+/** constructor */
+export function EventKey(e: Event): EventKey {
     return `${e.stpid}|${e.rtid}` as EventKey;
 }
 
@@ -328,22 +330,33 @@ class ReminderSubscriptions {
     }
 }
 
-const universityReminderSubscriptions = new ReminderSubscriptions();
+export const universityReminderSubscriptions = new ReminderSubscriptions();
+export const rideReminderSubscriptions = new ReminderSubscriptions();
 
-function processUniversityReminders() {
+export function processUniversityReminders() {
     try {
-        processRemindersHelper(state.cachedPredsByStopId, state.cachedPredsByVid);
+        processRemindersHelper(universityReminderSubscriptions, state.cachedPredsByStopId, state.cachedPredsByVid);
     } catch (e) {
         console.log("Processing university reminders failed");
         console.log(`${JSON.stringify(e)}`);
     }
 }
 
+export function processRideReminders() {
+    try {
+        processRemindersHelper(rideReminderSubscriptions, state.cachedRidePredsByStopId, state.cachedRidePredsByVid);
+    } catch (e) {
+        console.log("Processing ride reminders failed");
+        console.log(`${JSON.stringify(e)}`);
+    }
+}
+
 function processRemindersHelper(
+    reminderSubscriptions: ReminderSubscriptions,
     predsByStopId: Record<string, state.Prediction[] | undefined>,
     predsByVid: Record<string, state.Prediction[] | undefined>
 ) {
-    const notifications = universityReminderSubscriptions.process(predsByStopId, predsByVid, Date.now());
+    const notifications = reminderSubscriptions.process(predsByStopId, predsByVid, Date.now());
     for (const [eventKey, tokens] of notifications.reminder) {
         const event = decodeEvent(eventKey);
         const stopName = state.stopIdToName[event.stpid] ?? event.stpid;;
@@ -402,7 +415,7 @@ function sendReminderUpdateToAll(tokens: Set<string>) {
     }, tokens);
 }
 
-function sendNotifToAll(notif: { title: string, body: string }, tokens: Set<string>) {
+export function sendNotifToAll(notif: { title: string, body: string }, tokens: Set<string>) {
     sendToAll(
         { notification: notif },
         // { notification: notif, data: notif/*android: { notification: { ...notif, channel_id: "high_importance_channel" }}*/ },
@@ -445,15 +458,30 @@ function sendToAllHelper(msg: any, tokens: Set<string>) {
         });
 }
 
+export function infoToUseForRoute(rtid: string): {
+    reminderSubscriptions: ReminderSubscriptions,
+    predsByStopId: typeof state.cachedPredsByStopId,
+    predsByVid: typeof state.cachedPredsByVid
+} | null {
+    if (state.validRoutes.has(rtid)) {
+        return {
+            reminderSubscriptions: universityReminderSubscriptions,
+            predsByStopId: state.cachedPredsByStopId,
+            predsByVid: state.cachedPredsByVid,
+        };
+    } else if (state.validRideRoutes.has(rtid)) {
+        return {
+            reminderSubscriptions: rideReminderSubscriptions,
+            predsByStopId: state.cachedRidePredsByStopId,
+            predsByVid: state.cachedRidePredsByVid,
+        };
+    } else {
+        return null;
+    }
+}
+
 /** exported for tests */
 export const testing = {
     ReminderSubscriptions,
     eventsEqual
-};
-
-export {
-    processUniversityReminders,
-    universityReminderSubscriptions,
-    sendNotifToAll,
-    Event, EventKey, RegistrationToken,
 };

--- a/src/services/reminder.ts
+++ b/src/services/reminder.ts
@@ -160,9 +160,11 @@ class ReminderSubscriptions {
             if (s.subscription.stage === 0) {
                 // did the candidate vehicle change?
                 // PERF: caching these filter results might be good
+                const relevantPreds = (predsByStopId[s.subscription.event.stpid] ?? [])
+                    .filter((p) => p.rt === s.subscription.event.rtid);
                 const newCandidate = firstPredAfter(
                     s.subscription.mustBeAfter,
-                    (predsByStopId[s.subscription.event.stpid] ?? []).filter((p) => p.rt === s.subscription.event.rtid)
+                    relevantPreds
                 );
                 if (newCandidate === null) {
                     if (s.subscription.candidateVid !== null) {
@@ -359,7 +361,15 @@ function processRemindersHelper(
     }
     for (const [eventKey, tokens] of notifications.atTheStop) {
         const event = fromKey(eventKey);
-        const stopName = state.stopIdToName[event.stpid] ?? event.stpid;;
+        let stopName = event.stpid;
+        const universityName = state.stopIdToName[event.stpid];
+        const rideName = state.rideStopIdToName[event.stpid];
+        if (universityName) {
+            stopName = universityName;
+        }
+        if (rideName) {
+            stopName = rideName;
+        }
         sendToAll(
             {
                 notification: { title: 'Bus Arriving', body: `${event.rtid} is almost at ${stopName}` },
@@ -381,7 +391,15 @@ function processRemindersHelper(
     }
     for (const [eventKey, tokens] of notifications.disappeared) {
         const event = fromKey(eventKey);
-        const stopName = state.stopIdToName[event.stpid] ?? event.stpid;;
+        let stopName = event.stpid;
+        const universityName = state.stopIdToName[event.stpid];
+        const rideName = state.rideStopIdToName[event.stpid];
+        if (universityName) {
+            stopName = universityName;
+        }
+        if (rideName) {
+            stopName = rideName;
+        }
         sendNotifToAll(
             {
                 title: `Bus Disappeared`,

--- a/src/services/reminder.ts
+++ b/src/services/reminder.ts
@@ -188,8 +188,10 @@ class ReminderSubscriptions {
                     (predsByStopId[s.subscription.event.stpid] ?? []).filter((p) => p.rt === s.subscription.event.rtid)
                 );
                 if (newCandidate === null) {
-                    // no candidate
-                    disappeared = true;
+                    if (s.subscription.candidateVid !== null) {
+                        // no candidate now + existed before
+                        disappeared = true;
+                    }
                 } else {
                     const pred = prdctdnToNum(newCandidate.prdctdn);
                     if (newCandidate.vid !== s.subscription.candidateVid) {

--- a/src/services/reminderTypes.ts
+++ b/src/services/reminderTypes.ts
@@ -21,7 +21,6 @@ type CoreEvent = {
 
 export type BaseEvent = CoreEvent & {
     readonly __brand: "event"
-    equals(other: Event): boolean
 }
 
 export function sameBaseEvent(e1: CoreEvent, e2: CoreEvent): boolean {

--- a/src/services/reminderTypes.ts
+++ b/src/services/reminderTypes.ts
@@ -24,6 +24,10 @@ export type BaseEvent = CoreEvent & {
     equals(other: Event): boolean
 }
 
+export function sameBaseEvent(e1: CoreEvent, e2: CoreEvent): boolean {
+    return e1.stpid === e2.stpid && e1.rtid === e2.rtid;
+}
+
 export function eventsEqual(e1: BaseEvent, e2: BaseEvent): boolean {
     return e1.stpid === e2.stpid && e1.rtid === e2.rtid;
 }

--- a/src/services/reminderTypes.ts
+++ b/src/services/reminderTypes.ts
@@ -1,0 +1,63 @@
+/** The utility and POD types used for reminders */
+
+import stringify from "fast-json-stable-stringify";
+
+export type Key<T> = string & { readonly __brand: "key", readonly __phantomData: T };
+
+/** REQUIRES: the value passed in is safe to stringify */
+export function toKey<T>(x: T): Key<T> {
+    return stringify(x) as Key<T>;
+}
+
+export function fromKey<T>(key: Key<T>): T {
+    return JSON.parse(key);
+}
+
+/** internal */
+type CoreEvent = {
+    stpid: string,
+    rtid: string,
+}
+
+export type BaseEvent = CoreEvent & {
+    readonly __brand: "event"
+    equals(other: Event): boolean
+}
+
+export function eventsEqual(e1: BaseEvent, e2: BaseEvent): boolean {
+    return e1.stpid === e2.stpid && e1.rtid === e2.rtid;
+}
+
+/** factory */
+export function baseEvent(x: { stpid: string, rtid: string }): BaseEvent {
+    return Object.freeze(x) as BaseEvent;
+}
+
+export type ThresholdEvent = CoreEvent & {
+    threshold: number,
+    readonly __brand: "thresholdEvent"
+};
+
+/** factory */
+export function thresholdEvent(x: { stpid: string, rtid: string, threshold: number }): ThresholdEvent {
+    return x as ThresholdEvent;
+}
+
+export type DelayEvent = CoreEvent & {
+    prevPred: number,
+    currPred: number,    
+    readonly __brand: "delayEvent"
+};
+
+/** factory */
+export function delayEvent(x: { stpid: string, rtid: string, prevPred: number, currPred: number }): DelayEvent {
+    return x as DelayEvent;
+}
+
+
+export type RegistrationToken = string & { readonly __brand: "registrationToken" }
+
+export function registrationToken(x: string): RegistrationToken {
+    return x as RegistrationToken;
+}
+

--- a/src/services/ride.ts
+++ b/src/services/ride.ts
@@ -69,7 +69,9 @@ export async function fetchPredictions(stopIds: string[], routes: string[]) {
                     requestType: 'getpredictions',
                     stpid: chunk.join(','),
                     rt: routes.join(','),
-                    tmres: 's'
+                    tmres: 's',
+                    // theride doesn't seem to support unix timestamps so this doesn't do anything
+                    unixTime: true,
                 }
             });
             return res.data;

--- a/src/state/transitState.ts
+++ b/src/state/transitState.ts
@@ -10,7 +10,7 @@ export const cachedRoutes: Record<string, any> = {};
 export const cachedRideRoutes: Record<string, any> = {};
 
 /** Represents a bus prediction. */
-export type Prediction = { vid: string; stpid: string; prdtm: number, prdctdn: string } & Record<string, any>;
+export type Prediction = { rt: string, vid: string; stpid: string; prdtm: number, prdctdn: string } & Record<string, any>;
 
 /** Predictions indexed by vehicle ID. */
 export const cachedPredsByVid: Record<string, Prediction[]> = {};

--- a/src/state/transitState.ts
+++ b/src/state/transitState.ts
@@ -10,7 +10,7 @@ export const cachedRoutes: Record<string, any> = {};
 export const cachedRideRoutes: Record<string, any> = {};
 
 /** Represents a bus prediction. */
-export type Prediction = { vid: string; stpid: string; prdtm: number } & Record<string, any>;
+export type Prediction = { vid: string; stpid: string; prdtm: number, prdctdn: string } & Record<string, any>;
 
 /** Predictions indexed by vehicle ID. */
 export const cachedPredsByVid: Record<string, Prediction[]> = {};

--- a/src/state/transitState.ts
+++ b/src/state/transitState.ts
@@ -23,6 +23,8 @@ export const cachedRidePredsByStopId: Record<string, Prediction[]> = {};
 
 /** Map of stop IDs to their human-readable names. */
 export const stopIdToName: Record<string, string> = {};
+/** Map of ride stop IDs to their human-readable names. */
+export const rideStopIdToName: Record<string, string> = {};
 /** Map of trip IDs to route names. */
 export const tatripidToRt: Record<string, string> = {};
 

--- a/src/state/transitState.ts
+++ b/src/state/transitState.ts
@@ -10,7 +10,7 @@ export const cachedRoutes: Record<string, any> = {};
 export const cachedRideRoutes: Record<string, any> = {};
 
 /** Represents a bus prediction. */
-export type Prediction = { vid: string; stpid: string } & Record<string, any>;
+export type Prediction = { vid: string; stpid: string; prdtm: number } & Record<string, any>;
 
 /** Predictions indexed by vehicle ID. */
 export const cachedPredsByVid: Record<string, Prediction[]> = {};

--- a/test/reminder.test.ts
+++ b/test/reminder.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from 'vitest';
 
-import * as r from "./reminder";
-import { testing as t } from "./reminder";
-import { Prediction } from '../state/transitState';
-import { sortPreds } from './graphBuilder';
+import * as r from "@/services/reminder";
+import { testing as t } from "@/services/reminder";
+import { Prediction } from '@/state/transitState';
+import { sortPreds } from '@/services/graphBuilder';
 
-const testToken = r.RegistrationToken("token1");
-const testEvent = r.Event({ stpid: "stop1", rtid: "route1" });
-const testEventDiffRt = r.Event({ stpid: "stop1", rtid: "route2" });
+const testToken = r.registrationToken("token1");
+const testEvent = r.baseEvent({ stpid: "stop1", rtid: "route1" });
+const testEventDiffRt = r.baseEvent({ stpid: "stop1", rtid: "route2" });
 
 function createCaches(preds: Prediction[]): { byStop: Record<string, Prediction[]>, byVid: Record<string, Prediction[]> } {
     const byStop: Record<string, Prediction[]> = {};
@@ -52,7 +52,13 @@ describe('Reminders', () => {
         const remindersLater = subs.process(byStopLater, byVidLater, Date.now() + 60 * 1000);
         console.log(remindersLater);
         expect(remindersLater.reminder.size).toBe(1);
-        expect(remindersLater.reminder.get(r.EventKey(testEvent))?.has(testToken));
+        expect(
+            remindersLater.reminder.get(
+                Array.from(remindersLater.reminder.keys())
+                    .find((thresholdEvent) => r.sameBaseEvent(r.fromKey(thresholdEvent), testEvent))!
+            )!.has(testToken)
+        )
+            .toBe(true);
 
         expect(subs.activeRemindersFor(testToken).length).toBe(1);
         expect(t.eventsEqual(subs.activeRemindersFor(testToken)[0].event, testEvent)).toBe(true);
@@ -82,7 +88,7 @@ describe('Reminders', () => {
         const subs = new t.ReminderSubscriptions();
         subs.add(testEvent, 3, testToken, {}, Date.now());
         subs.add(testEventDiffRt, 3, testToken, {}, Date.now());
-        subs.add(testEvent, 3, r.RegistrationToken("anotherToken"), {}, Date.now());
+        subs.add(testEvent, 3, r.registrationToken("anotherToken"), {}, Date.now());
         expect(subs.subscriptions.length).toBe(3);
         subs.remove(testEvent, testToken);
         expect(subs.subscriptions.length).toBe(2);

--- a/test/reminder.test.ts
+++ b/test/reminder.test.ts
@@ -3,7 +3,10 @@ import { describe, it, expect } from 'vitest';
 import * as r from "@/services/reminder";
 import { testing as t } from "@/services/reminder";
 import { Prediction } from '@/state/transitState';
-import { sortPreds } from '@/services/graphBuilder';
+import * as state from '@/state/transitState';
+import { initializeRoutes, rebuildGraph, sortPreds, updateBusPositions } from '@/services/graphBuilder';
+import axios from 'axios';
+import { configDotenv } from 'dotenv';
 
 const testToken = r.registrationToken("token1");
 const testEvent = r.baseEvent({ stpid: "stop1", rtid: "route1" });
@@ -195,6 +198,47 @@ describe('Reminders', () => {
         const reminders = subs.process({}, {}, Date.now());
         expect(reminders.disappeared.size).toBe(0);
         expect(reminders.atTheStop.size).toBe(1);
+    });
+
+    it('should get unix timestamp from ride bus api', async () => {
+        configDotenv();
+        const RIDE_API_KEY = process.env.RIDE_API_KEY;
+        const BASE_URL = 'https://rt.theride.org/bustime/api/v3/';
+
+        const client = axios.create({
+            baseURL: BASE_URL,
+            params: { key: RIDE_API_KEY, format: 'json' }
+        });
+        const res = await client.get('/gettime', { params: { unixTime: true } });
+        expect(Math.abs(parseInt(res.data["bustime-response"]["tm"]) - Date.now())).toBeLessThan(60 * 1000);
+    });
+
+    it('should have cached preds in a good state', async () => {
+        // simulate one cycle of the core jobs
+        await initializeRoutes();
+        await rebuildGraph();
+        await updateBusPositions();
+        // are there preds?
+        expect(Object.keys(state.cachedPredsByStopId).length).toBeGreaterThan(0);
+        expect(Object.keys(state.cachedPredsByVid).length).toBeGreaterThan(0);
+        expect(Object.keys(state.cachedRidePredsByStopId).length).toBeGreaterThan(0);
+        expect(Object.keys(state.cachedRidePredsByVid).length).toBeGreaterThan(0);
+        // are the expected fields all there?
+        const sample: Prediction = { rt: "", stpid: "", vid: "", prdtm: 0, prdctdn: "" };
+        const allThere = (x: Prediction) => {
+            for (const k in sample) {
+                expect(k + ":" +typeof x[k]).toBe(k + ":" + typeof sample[k]);
+                if (k == "prdtm") {
+                    expect(x[k]).toBeGreaterThanOrEqual(Date.now() - 15 * 1000);
+                }
+            }  
+        };
+        [state.cachedPredsByStopId, state.cachedPredsByVid, state.cachedRidePredsByStopId, state.cachedRidePredsByVid]
+            .forEach((preds) => {
+                for (const k in preds) {
+                    preds[k].every(allThere);
+                }
+            });
     });
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { resolve } from "path";
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+    test: {
+        alias: [
+            { find: "@", replacement: resolve(__dirname, "./src") }
+        ]
+    }  
+})


### PR DESCRIPTION
Needed to make some changes to the graphbuilder service to store additional data in the prediction caches, prediction caches are also sorted by arrival time now. Added tests for basic coverage of reminder behavior and confirmation of some api things.